### PR TITLE
Fixed Translation (de) for "txtEncoding"

### DIFF
--- a/apps/documenteditor/main/locale/de.json
+++ b/apps/documenteditor/main/locale/de.json
@@ -189,7 +189,7 @@
   "Common.Views.OpenDialog.cancelButtonText": "Abbrechen",
   "Common.Views.OpenDialog.closeButtonText": "Datei schließen",
   "Common.Views.OpenDialog.okButtonText": "OK",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung ",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtIncorrectPwd": "Kennwort ist falsch.",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",
   "Common.Views.OpenDialog.txtPreview": "Vorschau",

--- a/apps/presentationeditor/main/locale/de.json
+++ b/apps/presentationeditor/main/locale/de.json
@@ -121,7 +121,7 @@
   "Common.Views.OpenDialog.cancelButtonText": "Abbrechen",
   "Common.Views.OpenDialog.closeButtonText": "Datei schließen",
   "Common.Views.OpenDialog.okButtonText": "OK",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtIncorrectPwd": "Kennwort ist falsch.",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",
   "Common.Views.OpenDialog.txtProtected": "Sobald Sie das Passwort eingegeben und die Datei geöffnet haben, wird das aktuelle Passwort für die Datei zurückgesetzt.",

--- a/apps/spreadsheeteditor/main/locale/de.json
+++ b/apps/spreadsheeteditor/main/locale/de.json
@@ -106,7 +106,7 @@
   "Common.Views.OpenDialog.txtColon": "Doppelpunkt",
   "Common.Views.OpenDialog.txtComma": "Komma",
   "Common.Views.OpenDialog.txtDelimiter": "Trennzeichen",
-  "Common.Views.OpenDialog.txtEncoding": "Verschlüsselung",
+  "Common.Views.OpenDialog.txtEncoding": "Zeichenkodierung",
   "Common.Views.OpenDialog.txtIncorrectPwd": "Kennwort ist falsch.",
   "Common.Views.OpenDialog.txtOther": "Sonstige",
   "Common.Views.OpenDialog.txtPassword": "Kennwort",

--- a/apps/spreadsheeteditor/mobile/locale/de.json
+++ b/apps/spreadsheeteditor/mobile/locale/de.json
@@ -218,7 +218,7 @@
   "SSE.Controllers.Main.txtDelimiter": "Trennzeichen",
   "SSE.Controllers.Main.txtDiagramTitle": "Diagrammtitel",
   "SSE.Controllers.Main.txtEditingMode": "Bearbeitungsmodus einschalten...",
-  "SSE.Controllers.Main.txtEncoding": "Verschlüsselung ",
+  "SSE.Controllers.Main.txtEncoding": "Zeichenkodierung",
   "SSE.Controllers.Main.txtErrorLoadHistory": "Laden der Historie ist fehlgeschlagen",
   "SSE.Controllers.Main.txtFiguredArrows": "Geformte Pfeile",
   "SSE.Controllers.Main.txtLines": "Linien",


### PR DESCRIPTION
Encoding should be translated to "Zeichenkodierung" not "Verschlüsselung"